### PR TITLE
feat: adding zustand for chat persisancy such as suggested prompts

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -7,7 +7,7 @@ const envSchema = z.object({
   OPENAI_API_LUKAS_KEY: z.string(),
   OPEN_API_LUKAS_ASSISTANT_ID: z.string(),
   OPEN_API_LUKAS_ASSISTANT_CONTEXT: z.string(),
-  OPENAI_MARCUS_API_KEY: z.string(),
+  OPENAI_API_MARCUS_KEY: z.string(),
   OPEN_API_MARCUS_ASSISTANT_ID: z.string(),
   OPEN_API_MARCUS_ASSISTANT_CONTEXT: z.string(),
 });

--- a/apps/api/src/openai.ts
+++ b/apps/api/src/openai.ts
@@ -56,7 +56,7 @@ export async function lukas(question: string, threadId?: string) {
 }
 
 const openaiMarcus = new OpenAI({
-  apiKey: env.OPENAI_MARCUS_API_KEY,
+  apiKey: env.OPENAI_API_MARCUS_KEY,
 });
 
 export async function marcus(question: string, threadId?: string) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,8 @@
     "remeda": "^2.21.3",
     "shiki": "^1.29.2",
     "sonner": "^2.0.3",
-    "tailwind-merge": "^3.2.0"
+    "tailwind-merge": "^3.2.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@personal-ai/eslint-config": "^1.0.0",

--- a/apps/web/src/app/components/ChatMessage.tsx
+++ b/apps/web/src/app/components/ChatMessage.tsx
@@ -1,10 +1,12 @@
 import { cn } from '@/lib/utils';
+import TypingIndicator from './TypingIndicator';
 
 interface ChatMessageProps {
   role: 'user' | 'assistant';
-  content: string;
+  content?: string;
   id?: string;
   className?: string;
+  loading?: boolean;
 }
 
 export function ChatMessage({
@@ -12,8 +14,17 @@ export function ChatMessage({
   content,
   id,
   className,
+  loading,
 }: ChatMessageProps) {
   const isUser = role === 'user';
+
+  if (loading) {
+    return (
+      <div className="flex justify-start items-center bg-primary-foreground text-muted-foreground rounded-lg px-4 py-2 text-black w-fit h-8">
+        <TypingIndicator />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/src/app/components/ChatSuggestedPrompts.tsx
+++ b/apps/web/src/app/components/ChatSuggestedPrompts.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/ui/button';
+
+function ChatSuggestedPrompts({
+  onPromptClick,
+}: {
+  onPromptClick: (prompt: string) => void;
+}) {
+  const suggestedPrompts = [
+    'What are your main skills as a fullstack developer?',
+    'Tell me about a project that you are really proud of',
+    'What companies or projects have you worked on?',
+  ];
+
+  return (
+    <div className="w-full h-full flex flex-col justify-center items-center">
+      <h1 className="my-10 text-2xl font-semibold">Try these Prompts</h1>
+      <div className="flex flex-col sm:flex-row items-center gap-4 justify-around w-full">
+        {suggestedPrompts.map((prompt, idx) => (
+          <Button
+            key={idx}
+            onClick={() => onPromptClick(prompt)}
+            className="w-full sm:max-w-[25%] p-5 h-fit break-words whitespace-pre-wrap text-sm cursor-pointer"
+          >
+            <p>{prompt}</p>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ChatSuggestedPrompts;

--- a/apps/web/src/app/components/ChatWindow.tsx
+++ b/apps/web/src/app/components/ChatWindow.tsx
@@ -3,25 +3,34 @@
 import { useEffect, useState } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { MessageInput } from './message-input';
-
-interface Message {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-}
+import { useStoreMarcusChat, useStoreLukasChat } from '@/hooks/use-store-chat';
+import { Message } from '../types/chat-store';
+import ChatSuggestedPrompts from './ChatSuggestedPrompts';
+import { usePathname } from 'next/navigation';
 
 interface ChatWindowProps {
   api: string;
 }
 
 export function ChatWindow({ api }: ChatWindowProps) {
-  const [messages, setMessages] = useState<Message[]>([]);
+  const pathName = usePathname();
+  const useStoreChat = pathName.includes('marcus')
+    ? useStoreMarcusChat
+    : useStoreLukasChat;
+  const messages = useStoreChat((state) => state.messages);
+  const addMessage = useStoreChat((state) => state.addMessage);
+  const setThreadId = useStoreChat((state) => state.setThreadId);
+  const threadId = useStoreChat((state) => state.threadId);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleSendMessage = async (message: string) => {
-    setMessages((prev) => [
-      ...prev,
-      { id: String(Date.now()), role: 'user', content: message },
-    ]);
+    const userMessage: Message = {
+      id: String(Date.now()),
+      role: 'user',
+      content: message,
+    };
+    addMessage(userMessage);
+    setIsLoading(true);
 
     try {
       const response = await fetch(api, {
@@ -29,32 +38,31 @@ export function ChatWindow({ api }: ChatWindowProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           message,
-          // threadId: '',
+          threadId,
         }),
       });
 
       const data = await response.json();
 
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: String(Date.now() + 1),
-          role: data.role,
-          content: data.response,
-        },
-      ]);
+      const userMessage: Message = {
+        id: String(Date.now() + 1),
+        role: data.role,
+        content: data.response,
+      };
+      addMessage(userMessage);
+      const userThreadId = data.threadId;
+      setThreadId(userThreadId);
     } catch (err) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: String(Date.now() + 2),
-          role: 'assistant',
-          content: 'Erro ao buscar resposta.',
-        },
-      ]);
+      const userMessage: Message = {
+        id: String(Date.now() + 2),
+        role: 'assistant',
+        content: 'Erro ao buscar resposta.',
+      };
+      addMessage(userMessage);
+    } finally {
+      setIsLoading(false);
     }
   };
-
   useEffect(() => {
     window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
   }, [messages]);
@@ -62,9 +70,13 @@ export function ChatWindow({ api }: ChatWindowProps) {
   return (
     <div className="relative w-full max-w-3xl mx-auto h-full flex flex-col">
       <div className="px-4 space-y-4" style={{ paddingBottom: '110px' }}>
+        {messages.length === 0 && (
+          <ChatSuggestedPrompts onPromptClick={handleSendMessage} />
+        )}{' '}
         {messages.map((msg) => (
           <ChatMessage key={msg.id} role={msg.role} content={msg.content} />
         ))}
+        {isLoading && <ChatMessage loading={true} role={'assistant'} />}
       </div>
       <div className="fixed bottom-0 left-0 w-full flex justify-center z-10">
         <div className="w-screen bg-[#1e1e1e] flex justify-center">

--- a/apps/web/src/app/components/TypingIndicator.tsx
+++ b/apps/web/src/app/components/TypingIndicator.tsx
@@ -1,0 +1,13 @@
+import { FaCircle } from 'react-icons/fa';
+
+function TypingIndicator() {
+  return (
+    <div className="flex gap-1">
+      <FaCircle className="animate-bounce" size={5} />
+      <FaCircle className="animate-bounce [animation-delay:.15s]" size={5} />
+      <FaCircle className="animate-bounce [animation-delay:.3s]" size={5} />
+    </div>
+  );
+}
+
+export default TypingIndicator;

--- a/apps/web/src/app/marcus/page.tsx
+++ b/apps/web/src/app/marcus/page.tsx
@@ -1,39 +1,12 @@
-import { Button } from '@/components/ui/button';
 import Header from '../components/Header';
-import Link from 'next/link';
-import ContactForm from '../components/ContactForm';
 import { marcus } from '../types/header-user';
+import { ChatWindow } from '../components/ChatWindow';
 
 function page() {
   return (
-    <div className="w-full h-full flex flex-col justify-center">
+    <div className="flex flex-col h-screen">
       <Header {...marcus} />
-      <main className="w-2/3 py-10 px-8 flex justify-center">
-        <div className="w-1/2 py-12 px-4">
-          <h1 className="text-3xl font-bold mb-3">
-            HI, I AM
-            <br /> MARCUS SANTOS
-          </h1>
-          <p className="text-lg mb-3">
-            Full-stack developer based in São Paulo, fueled by coffee and
-            passionate about turning ideas into digital solutions.
-          </p>
-          <Button
-            asChild
-            className="cursor-pointer bg-[#22c55e]/70 hover:bg-[#22c55e]/90 mr-5"
-          >
-            <Link href={'/resume'}>Download Resume</Link>
-          </Button>
-          <ContactForm>
-            <Link
-              href={''}
-              className="text-white/70 p-2.5 hover:bg-white/20 transition rounded-lg"
-            >
-              Contact Me
-            </Link>
-          </ContactForm>
-        </div>
-      </main>
+      <ChatWindow api={'http://localhost:3333/marcus'} />
     </div>
   );
 }

--- a/apps/web/src/app/types/chat-store.tsx
+++ b/apps/web/src/app/types/chat-store.tsx
@@ -1,0 +1,16 @@
+type Message = {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+type ChatStore = {
+  threadId: string | null;
+  messages: Message[];
+  setThreadId: (id: string) => void;
+  addMessage: (msg: Message) => void;
+  setMessages: (msgs: Message[]) => void;
+  clearChat: () => void;
+};
+
+export type { Message, ChatStore };

--- a/apps/web/src/hooks/use-store-chat.ts
+++ b/apps/web/src/hooks/use-store-chat.ts
@@ -1,0 +1,39 @@
+import { ChatStore } from '@/app/types/chat-store';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const useStoreMarcusChat = create<ChatStore>()(
+  persist(
+    (set) => ({
+      threadId: null,
+      messages: [],
+      setThreadId: (id) => set({ threadId: id }),
+      addMessage: (msg) =>
+        set((state) => ({ messages: [...state.messages, msg] })),
+      setMessages: (msgs) => set({ messages: msgs }),
+      clearChat: () => set({ threadId: null, messages: [] }),
+    }),
+    {
+      name: 'chat-storage',
+    },
+  ),
+);
+
+const useStoreLukasChat = create<ChatStore>()(
+  persist(
+    (set) => ({
+      threadId: null,
+      messages: [],
+      setThreadId: (id) => set({ threadId: id }),
+      addMessage: (msg) =>
+        set((state) => ({ messages: [...state.messages, msg] })),
+      setMessages: (msgs) => set({ messages: msgs }),
+      clearChat: () => set({ threadId: null, messages: [] }),
+    }),
+    {
+      name: 'chat-storage',
+    },
+  ),
+);
+
+export { useStoreMarcusChat, useStoreLukasChat };

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,8 @@
         "remeda": "^2.21.3",
         "shiki": "^1.29.2",
         "sonner": "^2.0.3",
-        "tailwind-merge": "^3.2.0"
+        "tailwind-merge": "^3.2.0",
+        "zustand": "^5.0.4"
       },
       "devDependencies": {
         "@personal-ai/eslint-config": "^1.0.0",
@@ -10365,6 +10366,35 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
+      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {


### PR DESCRIPTION
This pull request introduces several changes to enhance the chat functionality, improve user experience, and fix inconsistencies in environment variable naming. The most notable updates include implementing state management for chat messages using `zustand`, adding a typing indicator, introducing suggested prompts for empty chats, and refactoring the Marcus page to use the new chat window component.

### Chat Functionality Enhancements:
* **State Management for Chat Messages**: Added `zustand` for managing chat state, including thread IDs and messages, with separate stores for Marcus and Lukas chats (`apps/web/src/hooks/use-store-chat.ts`, `apps/web/src/app/types/chat-store.tsx`) [[1]](diffhunk://#diff-dc6325a2004c73857f53ed9996f0ff30f8d91fc3895f7e2d831ca2debe5e0ff9R1-R39) [[2]](diffhunk://#diff-9e831692a7e11f709065c3198bc6a26b07992bb62fc2491ce5e2e936347bb5fbR1-R16).
* **Typing Indicator**: Introduced a `TypingIndicator` component to display when the assistant is typing (`apps/web/src/app/components/TypingIndicator.tsx`, `apps/web/src/app/components/ChatMessage.tsx`) [[1]](diffhunk://#diff-bd0cc20463d1bdb3002f08942b4fcfb2369a13c3963385b5ec5f039dc9f2159cR1-R13) [[2]](diffhunk://#diff-95944c8912a9481d2d9ea98f60432a264f22a229ae5254ea65d2ea830d71edbcR2-R28).
* **Suggested Prompts**: Added a `ChatSuggestedPrompts` component to display predefined prompts when the chat is empty (`apps/web/src/app/components/ChatSuggestedPrompts.tsx`, `apps/web/src/app/components/ChatWindow.tsx`) [[1]](diffhunk://#diff-aaae5a05de73493f7ca157b2a3e7f8324e5f4f8def8e70d3d96a9b54309a0167R1-R32) [[2]](diffhunk://#diff-a9f9b7ba7749f0d13d7b26bd49106461aea3a31e384dfd095eb60684e40a3149L6-R79).

### Refactoring and Improvements:
* **Refactored Marcus Page**: Replaced the static content on the Marcus page with the new `ChatWindow` component for a dynamic chat experience (`apps/web/src/app/marcus/page.tsx`).
* **Environment Variable Fix**: Renamed `OPENAI_MARCUS_API_KEY` to `OPENAI_API_MARCUS_KEY` for consistency across the codebase (`apps/api/src/env.ts`, `apps/api/src/openai.ts`) [[1]](diffhunk://#diff-def34549453e3867a8b5fe4f49360ab06d6706fbe3d5c7f0d6ac71d228ff2690L10-R10) [[2]](diffhunk://#diff-05741e4268140ac254af76ba1aa820e31afa78d5ff1fffef0b4bcb88c7754024L59-R59).

### Dependency Updates:
* **Added Zustand**: Installed `zustand` for state management in the `apps/web` project (`apps/web/package.json`).…r the first prompt